### PR TITLE
ICU-13668 update ICU4C Demos to run in GCE

### DIFF
--- a/icu-kube/README.md
+++ b/icu-kube/README.md
@@ -3,7 +3,7 @@ Dockerized ICU4C Demos
 
 - Build with `sh build.sh`
 
-- Run with `docker run --rm -p 18080:80 unicode/icu4c-demos:latest` - will listen on port 18080
+- Run with `docker run --rm -p 18080:8080 unicode/icu4c-demos:latest` - will listen on port 18080
 
 ## Building with a special ICU version
 
@@ -37,7 +37,7 @@ $ docker build --build-arg ICU_PATH=http://999.999.999.999:5000/icu-r84d16d8c6c-
 - If all goes well (it did, right?): you can now run
 
 ```sh
-$ docker run --rm -p 8888:80 icu4c-demos:my-demos
+$ docker run --rm -p 8888:8080 icu4c-demos:my-demos
 ```
 
 … That will serve up the demos at http://localhost:8888/icu-bin/icudemos

--- a/icu-kube/docker.d/icu4c-demos/Dockerfile
+++ b/icu-kube/docker.d/icu4c-demos/Dockerfile
@@ -46,6 +46,7 @@ RUN if [ $ICU_PATH = "system" ]; then apk --update add icu-dev ; else apk --upda
 COPY --from=build /home/build/icu /home/build/icu
 RUN if [ -d /home/build/icu/usr/local ]; then (cd /home/build/icu/usr/; ln -sv local/* .); fi; ls -l /home/build/icu/usr/bin/
 ENV LD_LIBRARY_PATH /home/build/icu/usr/lib
-EXPOSE 80
+EXPOSE 8080
 COPY icu-kube/lighttpd.conf /etc/lighttpd/lighttpd.conf
+COPY icu-kube/index.html /var/www/localhost/htdocs/index.html
 CMD ["lighttpd", "-D", "-f", "/etc/lighttpd/lighttpd.conf"]

--- a/icu-kube/index.html
+++ b/icu-kube/index.html
@@ -1,0 +1,2 @@
+Click here for the <a href="./icu-bin/icudemos">ICU4C Demos</a>.
+

--- a/icu-kube/lighttpd.conf
+++ b/icu-kube/lighttpd.conf
@@ -1,7 +1,16 @@
 server.modules = ( "mod_alias", "mod_redirect", "mod_cgi" )
-server.document-root        = "/var/www/html" 
+server.document-root        = "/var/www/localhost/htdocs/" 
+index-file.names = ( "index.html" )
 
-server.port = 80
+server.port = 8080
+
+mimetype.assign = (
+  ".html" => "text/html", 
+  ".txt" => "text/plain",
+  ".jpg" => "image/jpeg",
+  ".png" => "image/png" 
+)
+
 
 $HTTP["url"] =~ "^/icu-bin/" {
     alias.url += ( "/icu-bin/" => "/home/build/icu/usr/bin/" )


### PR DESCRIPTION
[ICU-13668]

- document that the default port is now 8080 instead of 80

See: https://cloud.google.com/run/docs/migrating#listen_on_the_port_defined_by_the_port_environment_variable

GCE Run wants the `PORT` variable to be used, however, for now we just hard code the port (which the docs say not to do).

[ICU-13668]: https://unicode-org.atlassian.net/browse/ICU-13668