### PR TITLE
ICU-13668 C: update to support ICU_PATH=<icu4c tarball>

### DIFF
--- a/icu-kube/README.md
+++ b/icu-kube/README.md
@@ -7,31 +7,10 @@ Dockerized ICU4C Demos
 
 ## Building with a special ICU version
 
-(Advanced use)
-
-- use the [icu-docker repo with #15 fixed](https://github.com/unicode-org/icu-docker/pull/15) and create an alpine binary package:
+Use an ICU source tarball:
 
 ```sh
-$ make dist-some DISTROS_SMALL=alpine
-```
-
-Now serve up the `icu-r84d16d8c6c-x86_64-pc-linux-gnu-Alpine_Linux-3.10.2.tgz` (or similar) binary file:
-
-```sh
-$ cd icu-docker/src/dist/
-$ npx serve
-```
-
-Leave `npx serve` running in another window.
-
-Make a note of the IP address given by the `npx serve` command. Visit that URL and construct a URL to the `icu-r84d16d8c6c-x86_64-pc-linux-gnu-Alpine_Linux-3.10.2.tgz` file such as
-
-    http://999.999.999.999:5000/icu-r84d16d8c6c-x86_64-pc-linux-gnu-Alpine_Linux-3.10.2.tgz
-
-- Now you are ready to build:
-
-```sh
-$ docker build --build-arg ICU_PATH=http://999.999.999.999:5000/icu-r84d16d8c6c-x86_64-pc-linux-gnu-Alpine_Linux-3.10.2.tgz -t icu4c-demos:my-demos  . -f icu-kube/docker.d/icu4c-demos/Dockerfile
+$ docker build --build-arg ICU_PATH=https://github.com/unicode-org/icu/releases/download/release-65-1/icu4c-65_1-src.tgz -t icu4c-demos:my-demos  . -f icu-kube/docker.d/icu4c-demos/Dockerfile
 ```
 
 - If all goes well (it did, right?): you can now run

--- a/icu-kube/docker.d/icu4c-demos/Dockerfile
+++ b/icu-kube/docker.d/icu4c-demos/Dockerfile
@@ -14,7 +14,11 @@ RUN addgroup build && adduser -g "Build user" -h $HOME -S -G build -D -s /bin/sh
 ARG ICU_PATH
 ENV ICU_PATH=${ICU_PATH}
 
-RUN if [ $ICU_PATH = "system" ]; then apk --update add icu-dev; else curl -L $ICU_PATH | (cd / ; tar xvfpz - --strip-components 2 ); fi
+# The fun one. Note DEPS= speeds up the build when we're doing a one time compile.
+# nproc gives the number of processors.
+RUN if [ $ICU_PATH = "system" ]; then apk --update add icu-dev; \
+ else curl -L $ICU_PATH | (mkdir /tmp/icu && cd /tmp/icu && tar xvfpz - && \
+  cd icu/source && ./configure --prefix=/usr && make DEPS= -j$(nproc) install && make DEPS= -j$(nproc)  DESTDIR=/tmp/ICU/usr install); fi
 USER build
 
 # Wanted to use this: --wildcards -s '%icu[^/]*%%' 
@@ -25,14 +29,15 @@ ENV LD_LIBRARY_PATH /usr/local/lib
 # VOLUME /mnt/icu
 RUN icuinfo | tee /tmp/icuinfo.txt
 
-USER build
 # VOLUME /home/build
 RUN mkdir /home/build/build /home/build/src
 WORKDIR /home/build/build
-ADD . /home/build/src/
 ENV PREFIX=/home/build/icu
+RUN if [ -d /tmp/ICU ]; then mkdir -p /home/build/icu/ICU && cp -R /tmp/ICU /home/build/icu/ICU; fi
+ADD . /home/build/src/
 # HACK: translitdemo is not out of source enabled
 RUN cp -R /home/build/src/translitdemo /home/build/build/translitdemo
+#  No -j$(nproc) - not multithread safe!
 RUN ~/src/configure  --prefix=${PREFIX} ICU_CONFIG=$(which icu-config) && \
  make all install OBS= DESTDIR=${PREFIX} CONTEXTPATH=/icu-bin/ ICU_COMMON_HEADERS=/home/build/src/icu-kube/icuheaders
 #make -k DEPS= clean && make -k DEPS= distclean && sudo apt-get purge -y git subversion python3 doxygen zip curl g++ && sudo apt-get -y autoremove && sudo apt-get clean -y
@@ -44,9 +49,10 @@ USER root
 ARG ICU_PATH
 ENV ICU_PATH=${ICU_PATH}
 RUN apk --update add lighttpd
-# run this again. Two downloads, but keeps the layers smaller..
-RUN if [ $ICU_PATH = "system" ]; then apk --update add icu-dev ; else apk --update add libstdc++ curl ; curl -L $ICU_PATH | (cd / ; tar xvfpz - --strip-components 2 ); fi
 COPY --from=build /home/build/icu /home/build/icu
+# Try to re-install the same ICU
+RUN if [ $ICU_PATH = "system" ]; then apk --update add icu-dev; \
+ else apk --update add libstdc++ && cp -Rv /home/build/icu/ICU/ICU/usr/usr / && rm -rf /home/build/icu/ICU/usr ; fi
 RUN if [ -d /home/build/icu/usr/local ]; then (cd /home/build/icu/usr/; ln -sv local/* .); fi; ls -l /home/build/icu/usr/bin/
 ENV LD_LIBRARY_PATH /home/build/icu/usr/lib
 EXPOSE 8080


### PR DESCRIPTION
- now you can use a  --build-arg  to specify a tarball, instead of an (alpine!) linux package.
- this makes it simpler to build a 65.1 (for example) docker image more easily.

already deployed to http://demo.icu-project.org/icu-bin/icudemos and pushed as `unicode/icu4c-demos:65.1` to docker hub. The README explains how to build a docker image against a certain tarball.