### PR TITLE
'python' is not usable as a package in Alpine, use 'python3'

### DIFF
--- a/icu-kube/docker.d/icu4c-demos/Dockerfile
+++ b/icu-kube/docker.d/icu4c-demos/Dockerfile
@@ -7,7 +7,7 @@ LABEL maintainer="srl@icu-project.org"
 USER root
 ENV HOME /home/build
 
-RUN apk --update add gcc make python g++ ccache valgrind doxygen tar zip curl wget git bash bsd-compat-headers
+RUN apk --update add gcc make python3 g++ ccache valgrind pkgconfig doxygen tar zip curl wget git bash bsd-compat-headers
 RUN addgroup build && adduser -g "Build user" -h $HOME -S -G build -D -s /bin/sh build
 
 ## Change this to a file:///mnt/icu/blah.tgz to replace, or another URL.


### PR DESCRIPTION
make the Dockerfile buildable