### PR TITLE
Fix JS source URL in translit_rule_edit

### DIFF
--- a/translitdemo/data/translit_rule_edit.html
+++ b/translitdemo/data/translit_rule_edit.html
@@ -13,7 +13,7 @@ textarea { font-family: Arial Unicode MS; font-size: 100% }
 
 // Load up this stuff relative to the CGI
   SELF = "$SCRIPT_NAME";
-  JS = "$SCRIPT_NAME?TEMPLATE_FILE=data/js";
+  JS = "$SCRIPT_NAME?TEMPLATE_FILE=js";
 
 
 // Load up the js/util.js script.  This works as long as we cloak the tag.


### PR DESCRIPTION
Currently https://icu4c-demos.unicode.org/icu-bin/translit?TEMPLATE_FILE=data/translit_rule_main.html errors because of an incorrect JS path. The correct JS path is used in https://icu4c-demos.unicode.org/icu-bin/translit (and in https://github.com/unicode-org/icu-demos/blob/ab55de392f640bea7d251f12e24c3f8ecfb8b037/translitdemo/data/translit_template.html#L34)