### PR TITLE
Run from maven, without docker, for development

### DIFF
--- a/icu4jweb/Dockerfile
+++ b/icu4jweb/Dockerfile
@@ -1,4 +1,7 @@
 # Copyright (c) 2019 and later Unicode, Inc. and others. All Rights Reserved.
+
+# Keep the tomcat version and port in sync with the `cargo.containerId` and
+# the `cargo.servlet.port` in pom.xml
 FROM tomcat:9-jdk11-temurin
 ADD target/icu4jweb.war /usr/local/tomcat/webapps/
 EXPOSE 8080

--- a/icu4jweb/README.md
+++ b/icu4jweb/README.md
@@ -10,6 +10,15 @@
     <icu4j.version>78.3</icu4j.version>
     ```
 
+    or change it from from command line:
+
+    ```sh
+    mvn versions:set-property \
+      -Dproperty=icu4j.version \
+      -DnewVersion=78.3 \
+      -DgenerateBackupPoms=false
+    ```
+
     Before ICU 78 the versions was directly on the `<dependency>`:
 
     ```xml
@@ -23,7 +32,23 @@
     mvn package
     ```
 
-## RUNNING WITH [docker](https://docker.io)
+## Running without [docker](https://docker.io)
+
+```sh
+# Run without rebuilding:
+mvn cargo:run
+# Or build, and run:
+mvn package cargo:run
+# Or even clean, build, and run:
+mvn clean package cargo:run
+```
+
+The application will be available at http://localhost:8080/
+
+**Note:** this is convenient for development, but we still recommend testing
+with docker before deployment.
+
+## Running with [docker](https://docker.io)
 
 Note that this does not rebuild the demos, but just creates a new docker image for running locally.
 

--- a/icu4jweb/pom.xml
+++ b/icu4jweb/pom.xml
@@ -25,12 +25,20 @@ Copyright © 2016 and later Unicode, Inc. and others. All Rights Reserved.
     <maven.compiler.release>11</maven.compiler.release>
 
     <!-- Dependencies versions -->
-    <!-- UPDATE THE VERSION TO BUILD AND DEPLOY -->
+    <!-- UPDATE THE ICU4J VERSION TO BUILD AND DEPLOY -->
     <icu4j.version>78.3</icu4j.version>
     <junit.version>4.13.2</junit.version>
     <!-- Dependencies versions - END -->
 
+    <!-- Keep this info in sync with the Dockerfile
+         See here a complete list of supported containers:
+         https://codehaus-cargo.github.io/cargo/Container.html
+    -->
+    <cargo.containerId>tomcat9x</cargo.containerId>
+    <cargo.servlet.port>8080</cargo.servlet.port>
+
     <!-- Plugin versions -->
+    <cargo-maven3-plugin.version>1.10.27</cargo-maven3-plugin.version>
     <maven-clean-plugin.version>3.5.0</maven-clean-plugin.version>
     <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>
     <maven-deploy-plugin.version>3.1.4</maven-deploy-plugin.version>
@@ -88,6 +96,36 @@ Copyright © 2016 and later Unicode, Inc. and others. All Rights Reserved.
         <plugin>
           <artifactId>maven-deploy-plugin</artifactId>
           <version>${maven-deploy-plugin.version}</version>
+        </plugin>
+        <plugin>
+          <!-- To run:
+              mvn package cargo:run
+              The application will be available at http://localhost:8080/
+            -->
+          <groupId>org.codehaus.cargo</groupId>
+          <artifactId>cargo-maven3-plugin</artifactId>
+          <version>${cargo-maven3-plugin.version}</version>
+          <configuration>
+            <container>
+              <!-- Keep this in sync with the Dockerfile -->
+              <containerId>${cargo.containerId}</containerId>
+            </container>
+            <configuration>
+              <properties>
+                <cargo.servlet.port>${cargo.servlet.port}</cargo.servlet.port>
+              </properties>
+            </configuration>
+            <deployables>
+              <deployable>
+                <groupId>${project.groupId}</groupId>
+                <artifactId>${project.artifactId}</artifactId>
+                <type>war</type>
+                <properties>
+                  <context>/</context>
+                </properties>
+              </deployable>
+            </deployables>
+          </configuration>
         </plugin>
       </plugins>
     </pluginManagement>


### PR DESCRIPTION
With this one can execute `mvn package cargo:run` and it will download a tomcat version (in `target/`), deploy, and run.

No need to run `build-docker.sh`, which takes extra time, and creates a new docker image.
These docker images accumulate, take disk space, and need to be deleted once in a while.

You also don't need to have Docker installed.
