### PR TITLE
Fix ICU4C demos and update to ICU 78.3

### DIFF
--- a/icu-kube/README.md
+++ b/icu-kube/README.md
@@ -12,8 +12,9 @@ releases](https://github.com/unicode-org/icu/tags):
 
 Run this from the icu-demos directory:
 ```
-export RELEASE_PATH=https://github.com/unicode-org/icu/releases/download/release-70-1
-export LIB_TGZ=icu4c-70_1-src.tgz
+export ICU_VER=78.3
+export RELEASE_PATH=https://github.com/unicode-org/icu/releases/download/release-${ICU_VER}
+export LIB_TGZ=icu4c-${ICU_VER}-sources.tgz
 export RELEASE_LIB=$RELEASE_PATH/$LIB_TGZ
 
 echo $RELEASE_LIB
@@ -24,7 +25,7 @@ docker build --build-arg ICU_PATH=$RELEASE_LIB -t icu4c-demos:my-demos  . -f icu
 - If all goes well, you can now run
 
 ```sh
-docker run --rm -p 8888:8080 icu4c-demos:my-demos
+docker run --name icu4c-demos --rm -p 8888:8080 icu4c-demos:my-demos
 ```
 
 … That will serve up the demos at http://localhost:8888/icu-bin/icudemos

--- a/icu-kube/docker.d/icu4c-demos/Dockerfile
+++ b/icu-kube/docker.d/icu4c-demos/Dockerfile
@@ -1,11 +1,11 @@
 # © 2016 and later: Unicode, Inc. and others.
 # License & terms of use: http://www.unicode.org/copyright.html
 
-FROM alpine:latest as build
+FROM alpine:latest AS build
 LABEL maintainer="srl@icu-project.org"
 
 USER root
-ENV HOME /home/build
+ENV HOME=/home/build
 
 RUN apk --update add gcc make python3 g++ ccache valgrind pkgconfig doxygen tar zip curl wget git bash bsd-compat-headers
 RUN addgroup build && adduser -g "Build user" -h $HOME -S -G build -D -s /bin/sh build
@@ -23,7 +23,7 @@ USER build
 
 # Wanted to use this: --wildcards -s '%icu[^/]*%%' 
 
-ENV LD_LIBRARY_PATH /usr/local/lib
+ENV LD_LIBRARY_PATH=/usr/local/lib
 
 # Make sure ICU is installed and working
 # VOLUME /mnt/icu
@@ -44,7 +44,7 @@ RUN /home/build/src/configure  --prefix=${PREFIX} ICU_CONFIG=$(which icu-config)
 #RUN make all
 RUN cp -R /home/build/src/translitdemo /home/build/icu/translitdemo
 
-FROM alpine:latest as httpd
+FROM alpine:latest AS httpd
 USER root
 ARG ICU_PATH
 ENV ICU_PATH=${ICU_PATH}
@@ -54,7 +54,7 @@ COPY --from=build /home/build/icu /home/build/icu
 RUN if [ $ICU_PATH = "system" ]; then apk --update add icu-dev; \
  else apk --update add libstdc++ && cp -Rv /home/build/icu/ICU/ICU/usr/usr / && rm -rf /home/build/icu/ICU/usr ; fi
 RUN if [ -d /home/build/icu/usr/local ]; then (cd /home/build/icu/usr/; ln -sv local/* .); fi; ls -l /home/build/icu/usr/bin/
-ENV LD_LIBRARY_PATH /home/build/icu/usr/lib
+ENV LD_LIBRARY_PATH=/home/build/icu/usr/lib
 EXPOSE 8080
 # this needs special treatment
 RUN cp -v /home/build/icu/usr/bin/data/collation.html /var/www/localhost/htdocs/ || true

--- a/icuapps.mk.in
+++ b/icuapps.mk.in
@@ -88,3 +88,7 @@ endif
 
 # optional override file
 -include $(top_srcdir)/icuapps-mk.local
+
+# Enable standard POSIX / GNU C extensions globally (for strdup, strcasecmp, putenv)
+CFLAGS += -std=gnu11
+SHAREDLIBCFLAGS += -std=gnu11

--- a/locexp/locexp.h
+++ b/locexp/locexp.h
@@ -252,6 +252,7 @@ extern void chooseConverterMatching(LXContext *lx, const char *restored, UChar *
 
 extern void chooseConverterFrom(LXContext *lx, const char *restored, USort *list);
 extern void showOneLocale(LXContext *lx);
+extern void printBigString(LXContext *lx, const UChar *str);
 void showExploreBreak(LXContext *lx, const char *locale);
 
 /* fcns for dumping the contents of a particular rb */
@@ -279,6 +280,7 @@ extern void showSortStyle( LXContext *lx );
 
 extern void showExploreDateTimePatterns( LXContext *lx, UResourceBundle *rb, const char *locale);
 extern void showExploreNumberPatterns  ( LXContext *lx, const char *locale);
+extern void showNumberSystem(LXContext *lx, const char *locale, const char *nsys);
 
 extern const char *keyToSection( const char *key);
 extern void showExploreButtonPicture( LXContext *lx );

--- a/locexp/lxprint.c
+++ b/locexp/lxprint.c
@@ -7,6 +7,7 @@
 
 
 #include "locexp.h"
+#include "unicode/rescompat.h"
 #include <unicode/uscript.h>
 #include <unicode/ulocdata.h>
 /* #include "uresimp.h" */

--- a/locexp/lxsort.c
+++ b/locexp/lxsort.c
@@ -4,6 +4,7 @@
 ***********************************************************************/
 
 #include "locexp.h"
+#include "unicode/rescompat.h"
 #include "unicode/udata.h"
 #include "unicode/usearch.h"
 /* #include "uresimp.h" */

--- a/locexp/util/Makefile.in
+++ b/locexp/util/Makefile.in
@@ -48,7 +48,7 @@ OBJECTS += unumsys.o
 
 #OBJECTS +=  collectcb.o translitcb.o  kannada.o
 
-HEADERS = unicode/decompcb.h unicode/lx_utils.h unicode/ures_additions.h unicode/kangxi.h unicode/collectcb.h unicode/translitcb.h  unicode/cgiutil.h unicode/unumsys.h
+HEADERS = unicode/decompcb.h unicode/lx_utils.h unicode/ures_additions.h unicode/kangxi.h unicode/collectcb.h unicode/translitcb.h  unicode/cgiutil.h unicode/unumsys.h unicode/rescompat.h
 
 ## fontedcd  support
 #OBJECTS += fontedcb.o devanagari.o

--- a/locexp/util/cgiutil.c
+++ b/locexp/util/cgiutil.c
@@ -9,6 +9,7 @@
  */
 
 #include "unicode/cgiutil.h"
+#include "unicode/lx_utils.h"
 #include <unicode/ustdio.h>
 #include "unicode/unum.h"
 #include <stdarg.h>

--- a/locexp/util/unicode/rescompat.h
+++ b/locexp/util/unicode/rescompat.h
@@ -1,0 +1,23 @@
+/**********************************************************************
+*   Copyright (C) 2026, International Business Machines
+*   Corporation and others.  All Rights Reserved.
+***********************************************************************/
+
+#ifndef RESCOMPAT_H
+#define RESCOMPAT_H
+
+#include "unicode/utypes.h"
+
+/*
+ * These are non-public APIs, originals declared in icu4c/source/common/uresimp.h
+ */
+
+U_CAPI UResourceBundle* U_EXPORT2
+ures_findSubResource(const UResourceBundle *resB,
+       char* pathToResource,
+       UResourceBundle *fillIn, UErrorCode *status);
+
+U_CAPI UEnumeration* U_EXPORT2
+ures_getKeywordValues(const char *path, const char *keyword, UErrorCode *status);
+
+#endif

--- a/locexp/util/unicode/utimzone.h
+++ b/locexp/util/unicode/utimzone.h
@@ -22,7 +22,7 @@ U_CAPI UTimeZone *utz_open(const UChar *id);
 
 U_CAPI UTimeZone *utz_openDefault();
 
-U_CAPI int getID(const UTimeZone *zone, char *idbuf, int idlen);
+U_CAPI int utz_getID(const UTimeZone *zone, char *idbuf, int idlen);
 
 U_CAPI void utz_close(UTimeZone* zone);
 

--- a/translitdemo/Makefile
+++ b/translitdemo/Makefile
@@ -28,6 +28,7 @@ ICU_COMMON_HEADERS=$(ICU_SOURCE)/common
 
 
 include $(ICU_INC)
+CFLAGS += -std=gnu11
 
 # Name of your target
 TARGET=translit

--- a/translitdemo/textcachetool.make
+++ b/translitdemo/textcachetool.make
@@ -14,6 +14,7 @@ ICU_INC=/usr/local/lib/icu/Makefile.inc
 ###########################################
 
 include $(ICU_INC)
+CFLAGS += -std=gnu11
 
 # Name of your target
 TARGET=tct

--- a/ubrowse/ubrowse.c
+++ b/ubrowse/ubrowse.c
@@ -1320,7 +1320,7 @@ main(int argc,
 
   if(anyDecompose)
     {
-      u_fprintf(FSWF("NOTE_ANY_DECOMPOSE", "Note: text in <span class='anydecompose'>Italic Green</span> is the best-try using decomposition. Underscore (_) denotes missing characters in the decomposition."/*Note about green text*/), gOut);
+      u_fprintf(gOut, "%S", FSWF("NOTE_ANY_DECOMPOSE", "Note: text in <span class='anydecompose'>Italic Green</span> is the best-try using decomposition. Underscore (_) denotes missing characters in the decomposition."/*Note about green text*/));
     }
 
   uvi[0]=0xFF;


### PR DESCRIPTION
The changes here fix all the ICU4C demos
* "Unicode Browser", broken with ICU 78
* "Locale Explorer" and "Transforms", broken even with ICU 77.1 (deployed now) ("500 Internal Server Error")

And the README.md file is updated to account for the change in the naming of the released artifacts.

I tested all demos, and I think that with this both the ICU4C and ICU4J demos are ready to deploy with ICU 78.3.
